### PR TITLE
feat: add library navigation to explore card

### DIFF
--- a/concept-map/frontend/src/pages/dashboard.tsx
+++ b/concept-map/frontend/src/pages/dashboard.tsx
@@ -170,7 +170,10 @@ export default function DashboardPage() {
                   }}
                 />
                 
-                <div className="flex flex-col items-center p-6 border border-border rounded-lg hover:bg-muted/50 cursor-pointer transition-colors">
+                <div 
+                  onClick={() => navigate('/library')}
+                  className="flex flex-col items-center p-6 border border-border rounded-lg hover:bg-muted/50 cursor-pointer transition-colors"
+                >
                   <div className="p-3 bg-primary/10 rounded-full mb-4">
                     <svg className="h-6 w-6 text-primary" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                       <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 6.253v13m0-13C10.832 5.477 9.246 5 7.5 5S4.168 5.477 3 6.253v13C4.168 18.477 5.754 18 7.5 18s3.332.477 4.5 1.253m0-13C13.168 5.477 14.754 5 16.5 5c1.747 0 3.332.477 4.5 1.253v13C19.832 18.477 18.247 18 16.5 18c-1.746 0-3.332.477-4.5 1.253" />


### PR DESCRIPTION
# Add Library Navigation to Dashboard Explore Card

## Problem
The "Explore Public Maps" card on the dashboard currently doesn't navigate anywhere, making it non-functional for users wanting to explore public concept maps.

## Solution
This PR adds navigation functionality to the "Explore Public Maps" card:
- Adds onClick handler to navigate to `/library` route
- Maintains existing styling and user experience
- Uses React Router's `useNavigate` hook for client-side navigation

## Testing Required
Please verify:
- [ ] Clicking the "Explore Public Maps" card navigates to the library page
- [ ] Navigation is smooth and doesn't cause page reload
- [ ] Card hover and click states work as expected
- [ ] Other dashboard functionality remains unchanged

## Notes
This change improves the user experience by connecting the dashboard's explore functionality to the library page.