### PR TITLE
[CHECK 7th] Remove audio video file slash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ A powerful application for creating, sharing, and collaborating on concept maps 
   - [Code Style and Standards](#code-style-and-standards)
   - [Pull Request Process](#pull-request-process)
   - [Commit Message Guidelines](#commit-message-guidelines)
-  - [Branch Naming Convention](#branch-naming-convention)
   - [Issue Tracking](#issue-tracking)
 - [Contact](#contact)
 
@@ -30,6 +29,8 @@ Concept Map App is a web-based tool designed to help users create visual represe
 - **Interactive Concept Map Creation**: Drag-and-drop interface for creating nodes and connections
 - **User Accounts**: Personal dashboard to manage your concept maps
 - **Sharing and Collaboration**: Share your maps publicly or collaborate with specific users
+- **Notes & Learn**: Create and manage study notes with rich text editing
+- **Convert Notes to Concept Maps**: Automatically transform your notes into structured concept maps
 - **Templates and Examples**: Get started quickly with pre-built templates
 - **Responsive Design**: Works on desktop and mobile devices
 - **Export Options**: Save your maps in various formats (PNG, PDF, JSON)
@@ -43,6 +44,7 @@ The application follows a client-server architecture:
   - React with TypeScript, using Vite as the build tool
   - Built on [shadcn/ui](https://ui.shadcn.com/) components, a collection of reusable, accessible, and customizable UI components
   - Uses Tailwind CSS for styling
+  - BlockNote for rich text editing in the Notes feature
 - **Backend**: Python Flask API
 - **Data Storage**: Currently uses in-memory storage (JSON), with plans to integrate a database system
 
@@ -250,29 +252,29 @@ Types include:
 - `feat`: A new feature
 - `fix`: A bug fix
 - `docs`: Documentation only changes
-- `style`: Changes that don't affect the code's meaning
-- `refactor`: Code change that neither fixes a bug nor adds a feature
-- `perf`: Code change that improves performance
+- `style`: Changes that do not affect the meaning of the code
+- `refactor`: A code change that neither fixes a bug nor adds a feature
+- `perf`: A code change that improves performance
 - `test`: Adding missing tests or correcting existing tests
 - `chore`: Changes to the build process or auxiliary tools
 
-### Branch Naming Convention
-
-Use the following format for branch names:
-- `feature/short-description`: For new features
-- `bugfix/issue-number-short-description`: For bug fixes
-- `docs/what-you-are-documenting`: For documentation changes
-- `refactor/what-you-are-refactoring`: For code refactoring
-
 ### Issue Tracking
 
-1. **Check Existing Issues**: Before creating a new issue, check if it already exists
-2. **Issue Template**: Fill out the appropriate issue template
-3. **Labels**: Use appropriate labels for your issue
-4. **Assignees**: Don't assign issues to others unless discussed
-5. **Updates**: Keep the issue updated with your progress
+1. **Before submitting an issue**, search to see if it has already been reported
+2. **Use the issue templates** provided in the repository
+3. **Be clear and descriptive** about the problem or feature request
+4. **Provide steps to reproduce** for bug reports
+5. **Include screenshots** if applicable
+6. **Tag issues** appropriately with labels
 
 ## 📞 Contact
 
-For questions, feedback, or support, please contact:
-- GitHub Issues: [Create an issue](https://github.com/tjallingvds/concept_map_app/issues)
+For questions, suggestions, or discussions about the project, please:
+
+- Create an issue in the repository
+- Reach out through the project Notion workspace
+- Contact the project maintainers directly through their provided contact information
+
+---
+
+Thank you for your interest in contributing to the Concept Map App!

--- a/concept-map/backend/app.py
+++ b/concept-map/backend/app.py
@@ -1,6 +1,6 @@
 from flask import Flask, request, jsonify, session, send_from_directory
 from flask_cors import CORS
-from models import User, ConceptMap
+from models import User, ConceptMap, Note
 import os
 import secrets
 from werkzeug.utils import secure_filename
@@ -42,6 +42,7 @@ os.makedirs(UPLOAD_FOLDER, exist_ok=True)
 # In-memory storage (replace with database in production)
 concept_maps = []
 users = []  # List to store user objects
+notes = []  # List to store note objects
 
 # Initialize document processor
 document_processor = None
@@ -713,6 +714,309 @@ def list_models():
         return jsonify({
             "error": f"Failed to list models: {str(e)}"
         }), 500
+
+# Notes routes
+@app.route('/api/notes', methods=['GET'])
+def get_notes():
+    """Get all notes for the current user."""
+    # Get the user ID from session
+    user_id = session.get('user_id')
+    
+    if not user_id:
+        return jsonify({"error": "Not authenticated"}), 401
+        
+    # Filter notes by user_id and not deleted
+    user_notes = [n.to_dict() for n in notes if n.user_id == user_id and not n.is_deleted]
+    return jsonify(user_notes), 200
+
+@app.route('/api/notes', methods=['POST'])
+def create_note():
+    """Create a new note."""
+    # Get the user ID from session
+    user_id = session.get('user_id')
+    
+    if not user_id:
+        return jsonify({"error": "Not authenticated"}), 401
+        
+    data = request.json
+    
+    # Basic validation
+    if not data or 'title' not in data:
+        return jsonify({"error": "Missing required fields"}), 400
+    
+    # Generate a unique share ID
+    share_id = secrets.token_urlsafe(8)
+    
+    # Create a new note with a unique ID
+    new_note = Note(
+        title=data.get('title', 'Untitled Note'),
+        content=data.get('content', {}),
+        note_id=len(notes) + 1,
+        user_id=user_id,
+        is_public=data.get('is_public', False),
+        share_id=share_id,
+        is_favorite=data.get('is_favorite', False),
+        tags=data.get('tags', []),
+        description=data.get('description', '')
+    )
+    
+    notes.append(new_note)
+    return jsonify(new_note.to_dict()), 201
+
+@app.route('/api/notes/<int:note_id>', methods=['GET'])
+def get_note(note_id):
+    """Get a specific note by ID."""
+    # Get the user ID from session
+    user_id = session.get('user_id')
+    
+    if not user_id:
+        return jsonify({"error": "Not authenticated"}), 401
+        
+    note = next((n for n in notes if n.id == note_id and n.user_id == user_id and not n.is_deleted), None)
+    
+    if not note:
+        return jsonify({"error": "Note not found"}), 404
+    
+    return jsonify(note.to_dict()), 200
+
+@app.route('/api/shared/notes/<string:share_id>', methods=['GET'])
+def get_shared_note(share_id):
+    """Get a shared note by share ID."""
+    # This endpoint is public and doesn't require authentication
+    note = next((n for n in notes if n.share_id == share_id and n.is_public and not n.is_deleted), None)
+    
+    if not note:
+        return jsonify({"error": "Shared note not found or not public"}), 404
+    
+    return jsonify(note.to_dict()), 200
+
+@app.route('/api/notes/<int:note_id>', methods=['PUT'])
+def update_note(note_id):
+    """Update a specific note."""
+    # Get the user ID from session
+    user_id = session.get('user_id')
+    
+    if not user_id:
+        return jsonify({"error": "Not authenticated"}), 401
+        
+    data = request.json
+    
+    note = next((n for n in notes if n.id == note_id and n.user_id == user_id and not n.is_deleted), None)
+    
+    if not note:
+        return jsonify({"error": "Note not found"}), 404
+    
+    # Update the note fields
+    if 'title' in data:
+        note.title = data['title']
+    if 'content' in data:
+        note.content = data['content']
+    if 'is_public' in data:
+        note.is_public = data['is_public']
+    if 'is_favorite' in data:
+        note.is_favorite = data['is_favorite']
+    if 'tags' in data:
+        note.tags = data['tags']
+    if 'description' in data:
+        note.description = data['description']
+    
+    # Update the timestamp
+    note.updated_at = datetime.utcnow()
+    
+    return jsonify(note.to_dict()), 200
+
+@app.route('/api/notes/<int:note_id>', methods=['DELETE'])
+def delete_note(note_id):
+    """Delete a specific note (soft delete)."""
+    # Get the user ID from session
+    user_id = session.get('user_id')
+    
+    if not user_id:
+        return jsonify({"error": "Not authenticated"}), 401
+        
+    note = next((n for n in notes if n.id == note_id and n.user_id == user_id and not n.is_deleted), None)
+    
+    if not note:
+        return jsonify({"error": "Note not found"}), 404
+    
+    # Mark the note as deleted (soft delete)
+    note.is_deleted = True
+    note.updated_at = datetime.utcnow()
+    
+    return jsonify({"message": f"Note '{note.title}' deleted successfully"}), 200
+
+@app.route('/api/notes/<int:note_id>/share', methods=['POST'])
+def share_note(note_id):
+    """Generate or update a sharing link for a note."""
+    # Get the user ID from session
+    user_id = session.get('user_id')
+    
+    if not user_id:
+        return jsonify({"error": "Not authenticated"}), 401
+        
+    note = next((n for n in notes if n.id == note_id and n.user_id == user_id and not n.is_deleted), None)
+    
+    if not note:
+        return jsonify({"error": "Note not found"}), 404
+    
+    data = request.json or {}
+    
+    # Update the note's sharing settings
+    note.is_public = data.get('is_public', True)
+    
+    # Generate a new share ID if requested or if one doesn't exist
+    if data.get('regenerate', False) or not note.share_id:
+        note.share_id = secrets.token_urlsafe(8)
+    
+    # Create the sharing URL
+    share_url = f"{os.environ.get('FRONTEND_URL', 'http://localhost:5173')}/shared/notes/{note.share_id}"
+    
+    return jsonify({
+        "share_id": note.share_id,
+        "share_url": share_url,
+        "is_public": note.is_public
+    }), 200
+
+@app.route('/api/notes/<int:note_id>/convert', methods=['POST'])
+def convert_note_to_concept_map(note_id):
+    """Convert a note to a concept map."""
+    # Get the user ID from session
+    user_id = session.get('user_id')
+    
+    if not user_id:
+        return jsonify({"error": "Not authenticated"}), 401
+        
+    note = next((n for n in notes if n.id == note_id and n.user_id == user_id and not n.is_deleted), None)
+    
+    if not note:
+        return jsonify({"error": "Note not found"}), 404
+    
+    try:
+        # Extract text content from the BlockNote format
+        # This is a simplified approach - in a real implementation, you'd need
+        # to parse the BlockNote JSON structure and extract meaningful text
+        content_text = ""
+        if isinstance(note.content, dict) and "content" in note.content:
+            for block in note.content["content"]:
+                if "content" in block and block["content"]:
+                    for item in block["content"]:
+                        if "text" in item:
+                            content_text += item["text"] + " "
+        
+        # Fall back to title if content extraction fails
+        if not content_text.strip():
+            content_text = note.title
+        
+        # Import the text extraction function
+        from concept_map_generation.mind_map import extract_concept_map_from_text
+        
+        # Process the note content to generate concepts and relationships
+        concept_data = extract_concept_map_from_text(content_text)
+        
+        # Prepare nodes and edges
+        nodes = []
+        edges = []
+        
+        # Convert the concepts and relationships to nodes and edges
+        for concept in concept_data.get("concepts", []):
+            node = {
+                "id": concept.get("id", f"c{len(nodes)+1}"),
+                "label": concept.get("name", "Unnamed Concept"),
+                "description": concept.get("description", "")
+            }
+            nodes.append(node)
+        
+        for relationship in concept_data.get("relationships", []):
+            edge = {
+                "source": relationship.get("source", ""),
+                "target": relationship.get("target", ""),
+                "label": relationship.get("label", "relates to")
+            }
+            edges.append(edge)
+        
+        # Create a new concept map
+        share_id = secrets.token_urlsafe(8)
+        
+        # Generate SVG representation if possible
+        image = None
+        format_type = None
+        
+        if nodes and edges:
+            try:
+                from concept_map_generation.mind_map import generate_concept_map_svg
+                
+                # Create a concept map structure
+                concept_map_json = {
+                    "nodes": nodes,
+                    "edges": edges
+                }
+                
+                # Generate the SVG
+                image = generate_concept_map_svg(concept_map_json, "hierarchical")
+                format_type = "svg"
+            except Exception as img_error:
+                print(f"Error generating SVG for concept map: {str(img_error)}")
+        
+        # Create the new concept map
+        new_map = ConceptMap(
+            name=f"From note: {note.title}",
+            nodes=nodes,
+            edges=edges,
+            map_id=len(concept_maps) + 1,
+            user_id=user_id,
+            is_public=False,
+            share_id=share_id,
+            image=image,
+            format=format_type
+        )
+        
+        concept_maps.append(new_map)
+        
+        return jsonify({
+            "message": "Note converted to concept map successfully",
+            "concept_map": new_map.to_dict()
+        }), 201
+        
+    except Exception as e:
+        print(f"Error converting note to concept map: {str(e)}")
+        return jsonify({"error": f"Failed to convert note to concept map: {str(e)}"}), 500
+
+@app.route('/api/users/<int:user_id>/recent-notes', methods=['GET'])
+def get_recent_notes(user_id):
+    """Get the most recent notes for a user."""
+    # Get the user ID from session
+    session_user_id = session.get('user_id')
+    
+    if not session_user_id:
+        return jsonify({"error": "Not authenticated"}), 401
+    
+    # Check if the user is requesting their own notes
+    if session_user_id != user_id:
+        return jsonify({"error": "Unauthorized to access these notes"}), 403
+    
+    # Get recent notes, sorted by updated_at
+    user_notes = [n.to_dict() for n in notes if n.user_id == user_id and not n.is_deleted]
+    recent_notes = sorted(user_notes, key=lambda x: x.get('updated_at', ''), reverse=True)[:5]
+    
+    return jsonify(recent_notes), 200
+
+@app.route('/api/users/<int:user_id>/favorite-notes', methods=['GET'])
+def get_favorite_notes(user_id):
+    """Get the favorite notes for a user."""
+    # Get the user ID from session
+    session_user_id = session.get('user_id')
+    
+    if not session_user_id:
+        return jsonify({"error": "Not authenticated"}), 401
+    
+    # Check if the user is requesting their own notes
+    if session_user_id != user_id:
+        return jsonify({"error": "Unauthorized to access these notes"}), 403
+    
+    # Get favorite notes
+    favorite_notes = [n.to_dict() for n in notes if n.user_id == user_id and n.is_favorite and not n.is_deleted]
+    
+    return jsonify(favorite_notes), 200
 
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=5001, debug=True)

--- a/concept-map/backend/models.py
+++ b/concept-map/backend/models.py
@@ -145,6 +145,79 @@ class ConceptMap:
         )
 
 
+class Note:
+    """Model representing a user's note."""
+    
+    def __init__(self, title, content, note_id=None, user_id=None, is_public=False, 
+                 share_id=None, created_at=None, updated_at=None, is_favorite=False, 
+                 tags=None, description=None):
+        self.id = note_id
+        self.title = title
+        self.content = content  # This would store the BlockNote editor content as JSON
+        self.user_id = user_id  # To associate notes with users
+        self.is_public = is_public  # Whether the note is publicly accessible
+        self.share_id = share_id  # Unique ID for sharing the note
+        self.created_at = created_at or datetime.utcnow()
+        self.updated_at = updated_at or datetime.utcnow()
+        self.is_favorite = is_favorite  # Whether the note is marked as favorite
+        self.tags = tags or []  # List of tags for the note
+        self.description = description  # Brief description of the note
+        self.is_deleted = False  # For soft deletion
+    
+    def to_dict(self):
+        """Convert the model to a dictionary representation."""
+        return {
+            "id": self.id,
+            "title": self.title,
+            "content": self.content,
+            "user_id": self.user_id,
+            "is_public": self.is_public,
+            "share_id": self.share_id,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+            "is_favorite": self.is_favorite,
+            "tags": self.tags,
+            "description": self.description,
+            "is_deleted": self.is_deleted
+        }
+    
+    @classmethod
+    def from_dict(cls, data, note_id=None):
+        """Create a Note instance from a dictionary."""
+        created_at = None
+        if "created_at" in data and data["created_at"]:
+            try:
+                created_at = datetime.fromisoformat(data["created_at"])
+            except (ValueError, TypeError):
+                pass
+                
+        updated_at = None
+        if "updated_at" in data and data["updated_at"]:
+            try:
+                updated_at = datetime.fromisoformat(data["updated_at"])
+            except (ValueError, TypeError):
+                pass
+                
+        note = cls(
+            title=data.get("title", ""),
+            content=data.get("content", {}),
+            note_id=note_id or data.get("id"),
+            user_id=data.get("user_id"),
+            is_public=data.get("is_public", False),
+            share_id=data.get("share_id"),
+            created_at=created_at,
+            updated_at=updated_at,
+            is_favorite=data.get("is_favorite", False),
+            tags=data.get("tags", []),
+            description=data.get("description")
+        )
+        
+        if "is_deleted" in data:
+            note.is_deleted = bool(data["is_deleted"])
+            
+        return note
+
+
 class Node:
     """Model representing a node in a concept map."""
     

--- a/concept-map/frontend/src/App.tsx
+++ b/concept-map/frontend/src/App.tsx
@@ -69,9 +69,16 @@ function AppRoutes() {
         <Route path="/settings" element={<SettingsPage />} />
         <Route path="/editor/:id" element={<EditorPage />} />
         <Route path="/shared/:shareId" element={<SharedMapPage />} />
+        
+        {/* Notes routes */}
         <Route path="/notes" element={<NotesPage />} />
-        <Route path="/editor-notes" element={<EditorNotesPage />} />
-        <Route path="/editor-notes/:id" element={<EditorNotesPage />} />
+        <Route path="/notes/edit" element={<EditorNotesPage />} />
+        <Route path="/notes/edit/:id" element={<EditorNotesPage />} />
+        
+        {/* Keep for backward compatibility but redirect to the new paths */}
+        <Route path="/editor-notes" element={<Navigate to="/notes/edit" replace />} />
+        <Route path="/editor-notes/:id" element={<Navigate to="/notes/edit/:id" replace />} />
+        
         {/* Add more protected routes here */}
       </Route>
     </Routes>

--- a/concept-map/frontend/src/pages/editor-notes.tsx
+++ b/concept-map/frontend/src/pages/editor-notes.tsx
@@ -9,7 +9,12 @@ import { ArrowLeft, Save, GitMerge } from "lucide-react"
 import "@blocknote/core/fonts/inter.css"
 import { BlockNoteView } from "@blocknote/mantine"
 import "@blocknote/mantine/style.css"
-import { useCreateBlockNote } from "@blocknote/react"
+import { filterSuggestionItems } from "@blocknote/core"
+import { 
+  useCreateBlockNote, 
+  getDefaultReactSlashMenuItems, 
+  SuggestionMenuController
+} from "@blocknote/react"
 import { toast } from "sonner"
 import { notesApi, NoteItem, conceptMapsApi } from "../services/api"
 import { useAuth } from "../contexts/auth-context"
@@ -262,7 +267,20 @@ export default function EditorNotesPage() {
                   editor={editor}
                   theme="light"
                   className="h-full"
-                />
+                  slashMenu={false}
+                >
+                  <SuggestionMenuController
+                    triggerCharacter="/"
+                    getItems={async (query) => {
+                      // Get default items but filter out audio, video, and file
+                      const defaultItems = getDefaultReactSlashMenuItems(editor);
+                      const filteredItems = defaultItems.filter(
+                        (item) => !["Audio", "Video", "File"].includes(item.title)
+                      );
+                      return filterSuggestionItems(filteredItems, query);
+                    }}
+                  />
+                </BlockNoteView>
               </div>
             )}
           </div>

--- a/concept-map/frontend/src/pages/editor-notes.tsx
+++ b/concept-map/frontend/src/pages/editor-notes.tsx
@@ -11,48 +11,143 @@ import { BlockNoteView } from "@blocknote/mantine"
 import "@blocknote/mantine/style.css"
 import { useCreateBlockNote } from "@blocknote/react"
 import { toast } from "sonner"
+import { notesApi, NoteItem } from "../services/api"
+import { useAuth } from "../contexts/auth-context"
 
 export default function EditorNotesPage() {
   const { id } = useParams()
   const navigate = useNavigate()
+  const { user } = useAuth()
   const [noteName, setNoteName] = useState(`Note ${id || ""}`)
   const [isSaving, setIsSaving] = useState(false)
   const [isConverting, setIsConverting] = useState(false)
+  const [isLoading, setIsLoading] = useState(id ? true : false)
+  const [note, setNote] = useState<NoteItem | null>(null)
   
   // Create a BlockNote editor instance
   const editor = useCreateBlockNote()
   
+  // Load note data if editing an existing note
+  useEffect(() => {
+    if (id) {
+      loadNote(parseInt(id));
+    }
+  }, [id]);
+  
+  // Load note from the API
+  const loadNote = async (noteId: number) => {
+    try {
+      setIsLoading(true);
+      const noteData = await notesApi.getNote(noteId);
+      setNote(noteData);
+      setNoteName(noteData.title);
+      
+      // Load content into the editor
+      if (noteData.content && editor) {
+        try {
+          // The replaceBlocks method requires two parameters:
+          // 1. blocks to remove (we'll use all current blocks)
+          // 2. blocks to insert (the content from the note)
+          
+          // Get all current blocks in the editor
+          const currentBlocks = editor.document;
+          
+          // Determine the content to load
+          let contentToLoad = [];
+          if (Array.isArray(noteData.content)) {
+            contentToLoad = noteData.content;
+          } else if (noteData.content.content && Array.isArray(noteData.content.content)) {
+            contentToLoad = noteData.content.content;
+          }
+          
+          // Replace all blocks with the note content
+          if (contentToLoad.length > 0) {
+            editor.replaceBlocks(currentBlocks, contentToLoad);
+          } else {
+            console.warn("Note content is not in expected format");
+          }
+        } catch (error) {
+          console.error("Failed to load note content into editor:", error);
+          toast.error("Failed to load note content");
+        }
+      }
+    } catch (error) {
+      console.error("Error loading note:", error);
+      toast.error("Failed to load note");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+  
   // Handle saving notes
   const handleSaveNotes = async () => {
     try {
-      setIsSaving(true)
-      // In a real app, you would save to backend here
-      await new Promise(resolve => setTimeout(resolve, 1000)) // Simulate API call
-      toast.success("Note saved successfully!")
+      setIsSaving(true);
+      
+      // Get the current editor content as JSON
+      const editorContent = editor.topLevelBlocks;
+      
+      if (id) {
+        // Update existing note
+        const updatedNote = await notesApi.updateNote(parseInt(id), {
+          title: noteName,
+          content: editorContent
+        });
+        setNote(updatedNote);
+        toast.success("Note updated successfully!");
+      } else {
+        // Create new note
+        const newNote = await notesApi.createNote({
+          title: noteName,
+          content: editorContent
+        });
+        setNote(newNote);
+        // Update URL to include the new note ID for subsequent saves
+        navigate(`/notes/edit/${newNote.id}`, { replace: true });
+        toast.success("Note created successfully!");
+      }
     } catch (error) {
-      console.error("Error saving note:", error)
-      toast.error("Failed to save note")
+      console.error("Error saving note:", error);
+      toast.error("Failed to save note");
     } finally {
-      setIsSaving(false)
+      setIsSaving(false);
     }
-  }
+  };
 
   // Handle converting to concept map
   const handleConvertToConceptMap = async () => {
     try {
-      setIsConverting(true)
-      // In a real app, you would convert note content to concept map here
-      await new Promise(resolve => setTimeout(resolve, 1000)) // Simulate API call
-      toast.success("Note converted to concept map!")
-      // Navigate to the concept map editor with the converted data
-      // navigate("/editor/new?from=note&id=" + id)
+      setIsConverting(true);
+      
+      // If the note hasn't been saved yet, save it first
+      let noteId = id ? parseInt(id) : null;
+      
+      if (!noteId) {
+        // Create the note first
+        const editorContent = editor.topLevelBlocks;
+        const newNote = await notesApi.createNote({
+          title: noteName,
+          content: editorContent
+        });
+        noteId = newNote.id;
+        setNote(newNote);
+        // Update URL to include the new note ID
+        navigate(`/notes/edit/${newNote.id}`, { replace: true });
+      }
+      
+      // Convert note to concept map
+      const conceptMap = await notesApi.convertNoteToConceptMap(noteId);
+      
+      // Navigate to the concept map editor with the new map
+      toast.success("Note converted to concept map!");
+      navigate(`/editor/${conceptMap.id}`);
     } catch (error) {
-      console.error("Error converting note:", error)
-      toast.error("Failed to convert note to concept map")
+      console.error("Error converting note:", error);
+      toast.error("Failed to convert note to concept map");
     } finally {
-      setIsConverting(false)
+      setIsConverting(false);
     }
-  }
+  };
   
   return (
     <SidebarProvider>
@@ -79,7 +174,7 @@ export default function EditorNotesPage() {
                 variant="outline" 
                 size="sm" 
                 onClick={handleConvertToConceptMap} 
-                disabled={isConverting}
+                disabled={isConverting || isLoading}
                 className="flex items-center gap-1"
               >
                 <GitMerge className="h-4 w-4" />
@@ -89,7 +184,7 @@ export default function EditorNotesPage() {
                 variant="outline" 
                 size="sm" 
                 onClick={handleSaveNotes} 
-                disabled={isSaving}
+                disabled={isSaving || isLoading}
                 className="flex items-center gap-1"
               >
                 <Save className="h-4 w-4" />
@@ -100,13 +195,19 @@ export default function EditorNotesPage() {
           
           {/* Editor - Full Page */}
           <div className="flex-1 overflow-hidden">
-            <div className="h-full">
-              <BlockNoteView 
-                editor={editor}
-                theme="light"
-                className="h-full"
-              />
-            </div>
+            {isLoading ? (
+              <div className="h-full flex items-center justify-center">
+                <p className="text-muted-foreground">Loading note...</p>
+              </div>
+            ) : (
+              <div className="h-full">
+                <BlockNoteView 
+                  editor={editor}
+                  theme="light"
+                  className="h-full"
+                />
+              </div>
+            )}
           </div>
         </main>
       </div>

--- a/concept-map/frontend/src/pages/editor-notes.tsx
+++ b/concept-map/frontend/src/pages/editor-notes.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from "react-router-dom"
 import { SidebarProvider, SidebarTrigger } from "../components/ui/sidebar"
 import { AppSidebar } from "../components/app-sidebar"
 import { Button } from "../components/ui/button"
-import { ArrowLeft, Save } from "lucide-react"
+import { ArrowLeft, Save, GitMerge } from "lucide-react"
 
 // Import BlockNote components
 import "@blocknote/core/fonts/inter.css"
@@ -17,6 +17,7 @@ export default function EditorNotesPage() {
   const navigate = useNavigate()
   const [noteName, setNoteName] = useState(`Note ${id || ""}`)
   const [isSaving, setIsSaving] = useState(false)
+  const [isConverting, setIsConverting] = useState(false)
   
   // Create a BlockNote editor instance
   const editor = useCreateBlockNote()
@@ -33,6 +34,23 @@ export default function EditorNotesPage() {
       toast.error("Failed to save note")
     } finally {
       setIsSaving(false)
+    }
+  }
+
+  // Handle converting to concept map
+  const handleConvertToConceptMap = async () => {
+    try {
+      setIsConverting(true)
+      // In a real app, you would convert note content to concept map here
+      await new Promise(resolve => setTimeout(resolve, 1000)) // Simulate API call
+      toast.success("Note converted to concept map!")
+      // Navigate to the concept map editor with the converted data
+      // navigate("/editor/new?from=note&id=" + id)
+    } catch (error) {
+      console.error("Error converting note:", error)
+      toast.error("Failed to convert note to concept map")
+    } finally {
+      setIsConverting(false)
     }
   }
   
@@ -56,16 +74,28 @@ export default function EditorNotesPage() {
                 placeholder="Untitled Note"
               />
             </div>
-            <Button 
-              variant="outline" 
-              size="sm" 
-              onClick={handleSaveNotes} 
-              disabled={isSaving}
-              className="flex items-center gap-1"
-            >
-              <Save className="h-4 w-4" />
-              {isSaving ? "Saving..." : "Save"}
-            </Button>
+            <div className="flex items-center gap-2">
+              <Button 
+                variant="outline" 
+                size="sm" 
+                onClick={handleConvertToConceptMap} 
+                disabled={isConverting}
+                className="flex items-center gap-1"
+              >
+                <GitMerge className="h-4 w-4" />
+                {isConverting ? "Converting..." : "Convert to Concept Map"}
+              </Button>
+              <Button 
+                variant="outline" 
+                size="sm" 
+                onClick={handleSaveNotes} 
+                disabled={isSaving}
+                className="flex items-center gap-1"
+              >
+                <Save className="h-4 w-4" />
+                {isSaving ? "Saving..." : "Save"}
+              </Button>
+            </div>
           </div>
           
           {/* Editor - Full Page */}


### PR DESCRIPTION
# Remove Audio, Video, and File Options from Note Editor Slash Commands

## Summary
This PR removes the audio, video, and file options from the BlockNote editor's slash commands menu in the notes editor. These options weren't needed for our use case and removing them simplifies the editor interface for users.

## Changes Made
- Disabled the default slash menu in the BlockNoteView component
- Added a custom SuggestionMenuController that:
  - Triggers on the slash ("/") character
  - Gets all default slash menu items
  - Filters out "Audio", "Video", and "File" options
  - Uses the filtered list for displaying suggestions to users

## Implementation Details
The implementation uses BlockNote's recommended approach for customizing slash menu items by:
1. Setting `slashMenu={false}` to disable the default slash menu
2. Adding a SuggestionMenuController as a child component
3. Using the filterSuggestionItems helper from @blocknote/core
4. Filtering the menu items by title to remove unwanted options

## Testing
- Verified that slash menu appears when typing "/"
- Confirmed that audio, video, and file options no longer appear in the menu
- Tested that all other slash menu functionality works as expected

## Screenshots
<img width="1680" alt="Screenshot 2025-04-19 at 02 00 22" src="https://github.com/user-attachments/assets/af0d0ff9-0421-4303-8e6b-986fada1d3a4" />
<img width="1680" alt="Screenshot 2025-04-19 at 02 00 40" src="https://github.com/user-attachments/assets/45b82de1-5c6a-4bb6-accf-bd022fb24e15" />
