### PR TITLE
Improve Handdrawn Whiteboard Experience and Fix TLDraw Deprecation Issues

### DIFF
--- a/concept-map/backend/auth_utils.py
+++ b/concept-map/backend/auth_utils.py
@@ -11,7 +11,21 @@ from models import User, db
 AUTH0_DOMAIN = os.getenv("AUTH0_DOMAIN", "your-tenant.auth0.com")
 API_AUDIENCE = os.getenv("AUTH0_API_AUDIENCE", "https://your-api-identifier")
 JWKS_URL = f"https://{AUTH0_DOMAIN}/.well-known/jwks.json"
-JWKS = requests.get(JWKS_URL).json()
+
+# Safely get JWKS with error handling
+try:
+    response = requests.get(JWKS_URL)
+    if response.status_code != 200:
+        print(f"Error fetching JWKS: HTTP {response.status_code}")
+        print(f"Please check your AUTH0_DOMAIN environment variable (current: {AUTH0_DOMAIN})")
+        JWKS = {"keys": []}  # Empty JWKS as fallback
+    else:
+        JWKS = response.json()
+except requests.exceptions.RequestException as e:
+    print(f"Network error fetching JWKS: {e}")
+    print(f"Please check your AUTH0_DOMAIN environment variable (current: {AUTH0_DOMAIN})")
+    print("Make sure you've set up the correct Auth0 domain in your .env file")
+    JWKS = {"keys": []}  # Empty JWKS as fallback
 
 jwt = JsonWebToken(["RS256"])
 

--- a/concept-map/backend/requirements.txt
+++ b/concept-map/backend/requirements.txt
@@ -77,4 +77,3 @@ Werkzeug==3.1.3
 wordcloud==1.9.4
 zipp==3.21.0
 authlib==1.5.2
-google-generativeai==0.8.5

--- a/concept-map/frontend/src/components/whiteboard-editor.tsx
+++ b/concept-map/frontend/src/components/whiteboard-editor.tsx
@@ -1,5 +1,5 @@
 import * as React from "react"
-import { Tldraw, Editor } from '@tldraw/tldraw'
+import { Tldraw, Editor, loadSnapshot } from '@tldraw/tldraw'
 import '@tldraw/tldraw/tldraw.css'
 import { Button } from "./ui/button"
 
@@ -16,8 +16,8 @@ export function WhiteboardEditor({ whiteboardContent, onSave, readOnly = false }
   React.useEffect(() => {
     if (editor && whiteboardContent) {
       try {
-        // Load the saved snapshot into the editor
-        editor.store.loadSnapshot(whiteboardContent)
+        // Load the saved snapshot into the editor using the recommended method
+        loadSnapshot(editor.store, whiteboardContent)
       } catch (error) {
         console.error("Error loading whiteboard content:", error)
       }


### PR DESCRIPTION
1. **Restructured map type options for clarity**
   - Removed "drawing" map type option which was causing confusion
   - Kept "handdrawn" as the map type for all hand-drawn content

2. **Created a more intuitive UI flow** 
   - Implemented dynamic tabs based on selected map type
   - For "handdrawn" maps: Show "Digitize Drawing" and "Whiteboard" tabs
   - For other map types (mindmap, wordcloud, bubblechart): Show "File" and "Text" tabs

3. **Renamed options for clarity**
   - Renamed "Empty Canvas" to "Digitize Drawing" to better represent its OCR functionality
   - Retained "Whiteboard" tab for pure freeform sketching without digitization

4. **Fixed whiteboard content saving**
   - Added proper format field handling in the API
   - Ensured correct format ("handdrawn") is set in backend requests
   - Added whiteboard_content field support in API requests
   - Fixed navigation to whiteboard editor after creation

5. **Fixed TLDraw deprecation warning**
   - Updated WhiteboardEditor to use the recommended loadSnapshot API
   - Fixed parameters to match current TLDraw requirements

This PR improves the user experience by making a clear distinction between digitizable drawings (that can be transformed into concept maps) and freeform whiteboards (that remain as handdrawn sketches
<img width="675" alt="Screenshot 2025-04-21 at 12 01 35 AM" src="https://github.com/user-attachments/assets/2a520d22-7362-4a82-8b2a-d979391d3db7" />
).
<img width="675" alt="Screenshot 2025-04-21 at 12 01 32 AM" src="https://github.com/user-attachments/assets/dca13108-eaa0-490d-914d-5c983345abdc" />

