### PR TITLE
Fixed Whiteboard Editor Save Functionality

### DIFF
--- a/concept-map/frontend/src/components/whiteboard-editor.tsx
+++ b/concept-map/frontend/src/components/whiteboard-editor.tsx
@@ -81,21 +81,22 @@ export const WhiteboardEditor = React.forwardRef<WhiteboardEditorRef, Whiteboard
     }), [getCurrentContent]);
 
     return (
-      <div className="whiteboard-editor-container flex flex-col h-full">
+      <div className="whiteboard-editor-container flex flex-col h-full relative">
+        {/* Save button positioned in top-right corner */}
+        {!readOnly && onSave && !hideSaveButton && (
+          <div className="absolute top-4 right-4 z-50">
+            <Button onClick={handleSave} variant="default" className="shadow-md">
+              Save Changes
+            </Button>
+          </div>
+        )}
+        
         <div className="flex-grow relative" style={{ minHeight: "100%" }}>
           <Tldraw
             onMount={setEditor}
             autoFocus
           />
         </div>
-        
-        {!readOnly && onSave && !hideSaveButton && (
-          <div className="mt-4 flex justify-end">
-            <Button onClick={handleSave}>
-              Save Changes
-            </Button>
-          </div>
-        )}
       </div>
     )
   }

--- a/concept-map/frontend/src/pages/whiteboard-editor-page.tsx
+++ b/concept-map/frontend/src/pages/whiteboard-editor-page.tsx
@@ -136,6 +136,19 @@ export default function WhiteboardEditorPage() {
     }
   }
 
+  // Reference to the whiteboard editor component
+  const editorRef = React.useRef<React.ElementRef<typeof WhiteboardEditor>>(null)
+  
+  // Function to save the current whiteboard state
+  const saveWhiteboard = React.useCallback(() => {
+    if (editorRef.current) {
+      const content = editorRef.current.getCurrentContent()
+      if (content) {
+        handleSave(content)
+      }
+    }
+  }, [handleSave])
+
   if (loading) {
     return (
       <div className="flex items-center justify-center h-screen">
@@ -155,7 +168,14 @@ export default function WhiteboardEditorPage() {
               <SidebarTrigger />
               <span className="text-sm font-medium">{map?.name || "Hand-Drawn Whiteboard"}</span>
             </div>
-            <div>
+            <div className="flex items-center gap-2">
+              <Button 
+                onClick={saveWhiteboard} 
+                disabled={saving}
+                className="shadow-sm"
+              >
+                {saving ? 'Saving...' : 'Save Changes'}
+              </Button>
               <Button variant="outline" onClick={() => navigate("/maps")}>
                 Back to Maps
               </Button>
@@ -165,8 +185,10 @@ export default function WhiteboardEditorPage() {
           <div className="flex-1 overflow-hidden">
             <div className="h-full w-full">
               <WhiteboardEditor 
+                ref={editorRef}
                 whiteboardContent={map.whiteboardContent}
                 onSave={handleSave}
+                hideSaveButton={true}
               />
             </div>
           </div>


### PR DESCRIPTION
In this PR, we addressed a usability issue with the whiteboard editor's save button by:

1. Moving the save button from the bottom of the WhiteboardEditor component (where it was hidden behind the drawing palette) to the top header bar next to the "Back to Maps" button
2. Adding visual feedback during the save operation with a disabled state and "Saving..." text
3. Implementing a ref-based approach to directly access the whiteboard content from the parent component
4. Adding the hideSaveButton prop to the WhiteboardEditor to prevent duplicate save buttons

These changes make the save functionality more discoverable and intuitive for users, ensuring they don't lose their work and can easily save their whiteboard diagrams.
